### PR TITLE
rework internal tree representation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI/PR
+name: vim.ci
 on: [push, pull_request]
 jobs:
   linux:
@@ -15,7 +15,7 @@ jobs:
       - name: Install Dependencies
         run: sudo apt install -y vim
       - name: Run Tests
-        run: ./vim-themis/bin/themis
+        run: ./vim-themis/bin/themis --reporter spec
   macos:
     runs-on: macos-latest
     steps:
@@ -27,5 +27,5 @@ jobs:
       - name: Install Dependencies
         run: brew install vim
       - name: Run Tests
-        run: ./vim-themis/bin/themis
+        run: ./vim-themis/bin/themis --reporter spec
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # java-support.vim
-![CI/PR](https://img.shields.io/github/workflow/status/brandon1024/java-support.vim/CI/PR)
-![Documentation](https://img.shields.io/badge/Documentation-java--support.txt-brightgreen)
+![vim.ci](https://img.shields.io/github/workflow/status/brandon1024/java-support.vim/vim.ci)
+[![Documentation](https://img.shields.io/badge/Documentation-java--support.txt-brightgreen)](https://github.com/brandon1024/java-support.vim/blob/main/doc/java-support.txt)
 
 A Vim plugin for easier editing of Java files. Rearrange, optimize, and
 reformat import statements. Import classes easily with the help of tag files.
@@ -101,8 +101,6 @@ import java.io.ObjectInputFilter.Status;
 import java.io.SSLException;
 import java.io.StringWriter;
 import java.util.*;
-import java.util.Collections;
-import java.util.List;
 
 // let g:java_import_wildcard_count = 3
 import java.io.*;

--- a/autoload/buffer.vim
+++ b/autoload/buffer.vim
@@ -34,10 +34,10 @@ endfunction
 " The lines are removed from the buffer.
 " Lines are trimmed of leading/trailing whitespace. Duplicate lines are
 " removed.
-function! buffer#FilterLinesMatchingPattern(patt) abort
+function! buffer#FilterLinesMatchingPattern(lnum, patt) abort
 	let l:lines = []
 
-	let l:lnum = 1
+	let l:lnum = a:lnum
 	while l:lnum > 0
 		let l:lnum = buffer#FindLineMatchingPattern(l:lnum, a:patt)
 		if l:lnum

--- a/autoload/sort.vim
+++ b/autoload/sort.vim
@@ -101,14 +101,16 @@ function! s:TruncateBlankLines(lnum)
 	return buffer#TruncateToPattern(a:lnum, '^\s*$', '^.')
 endfunction
 
-" Sort and write the given import trees `trees` to the current buffer.
+" Sort and write the given import trees `tree` to the current buffer.
 " Assumes that all import statements have already been removed from the
 " buffer.
-function! sort#JavaSortImportsTrees(trees) abort
+function! sort#JavaSortImportsTrees(tree) abort
 	" sort import statements according to configuration
 	let l:imports = s:SortImportStatements(util#Flatten([
-		\ import_tree#Flatten(a:trees['s'], [], 'import static ', ';'),
-		\ import_tree#Flatten(a:trees['ns'], [], 'import ', ';')
+		\ import_tree#Flatten(a:tree,
+			\ { 'prefix': 'import static ', 'postfix': ';', 'filter': { 's': v:true } }),
+		\ import_tree#Flatten(a:tree,
+			\ { 'prefix': 'import ', 'postfix': ';', 'filter': { 's': v:false } })
 	\ ]))
 
 	" truncate leading blank lines
@@ -135,6 +137,6 @@ function! sort#JavaSortImports() abort
 		return
 	endif
 
-	call sort#JavaSortImportsTrees(import_tree#Build())
+	call sort#JavaSortImportsTrees(import_tree#BuildFromBuffer(v:true))
 endfunction
 

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -206,12 +206,6 @@ Illegal Java Syntax~
 	If you're editing a particularly bad Java file--one that doesn't adhere to
 	the Java specification--the plugin might not behave correctly.
 
-Compound Import Statements~
-	If you have multiple import statements on the same line (as shown below),
-	the plugin will only read the first import and will discard any remaining
-	on that line. Split your import statements (one per line) and rerun the
-	tool.
-
 Classes in Base Package~
 	This plugin relies on package statements to determine the fully-qualified
 	classname. If classes exist in the base package (and don't have an import

--- a/test/input/ImportClassPackageNameMatchBug.java
+++ b/test/input/ImportClassPackageNameMatchBug.java
@@ -1,0 +1,11 @@
+package ca.example.vim;
+
+import ca.example.vim.Internal;
+import ca.example.vim.Internal.Interface;
+
+public class ImportClassPackageNameMatchBug {
+    public ImportClassPackageNameMatchBug() {}
+}
+
+// if we have a package and class with the same name, the plugin would remove the first one when building the import tree. This source file is used to validate the fix.
+

--- a/test/input/NestedClasses.java
+++ b/test/input/NestedClasses.java
@@ -1,0 +1,13 @@
+public class NestedClasses {
+
+    public NestedClasses() {}
+
+    public static class StaticInnerClass {
+        public StaticInnerClass() {}
+    }
+
+    public class InnerClass {
+        public InnerClass() {}
+    }
+}
+

--- a/test/integration/sort.vimspec
+++ b/test/integration/sort.vimspec
@@ -171,6 +171,16 @@ Describe sort
 			let l:import_lines = buffer#FindLinesMatchingPattern(1, '^import ca\.example\.vim\.internal')
 			Assert Equals(len(l:import_lines), 2)
 		End
+
+		It should not merge imports where a class name matches a component of a package for another import
+			edit! test/input/ImportClassPackageNameMatchBug.java
+
+			call sort#JavaSortImports()
+
+			" ensure imports were not collapsed into one
+			Assert True(buffer#FindLineMatchingPattern(1, 'import ca.example.vim.Internal;') > 0)
+			Assert True(buffer#FindLineMatchingPattern(1, 'import ca.example.vim.Internal.Interface;') > 0)
+		End
 	End
 End
 

--- a/test/unit/buffer.vimspec
+++ b/test/unit/buffer.vimspec
@@ -71,7 +71,7 @@ Describe buffer
 
 			let l:initial_linecount = line('$')
 
-			let l:lines = buffer#FilterLinesMatchingPattern('import')
+			let l:lines = buffer#FilterLinesMatchingPattern(1, 'import')
 			Assert Equals(len(l:lines), 8)
 
 			let l:lines = buffer#FindLinesMatchingPattern(1, 'import')

--- a/test/unit/import_tree.vimspec
+++ b/test/unit/import_tree.vimspec
@@ -1,25 +1,159 @@
 Describe import_tree
+	Describe #BuildFromBuffer
+		Before
+			%bwipeout!
+		End
+
+		It should remove import statements from the buffer if arg is true
+			edit! test/input/StaticImports.java
+
+			call import_tree#BuildFromBuffer(v:true)
+			let l:lines = buffer#FindLinesMatchingPattern(1, 'import')
+			Assert Equal(len(l:lines), 0)
+		End
+
+		It should not remove import statements from the buffer if arg is false
+			edit! test/input/StaticImports.java
+
+			call import_tree#BuildFromBuffer(v:false)
+			let l:lines = buffer#FindLinesMatchingPattern(1, 'import')
+			Assert True(len(l:lines) > 0)
+		End
+
+		It should correctly build an import tree from the statements in the buffer
+			edit! test/input/StaticImports.java
+
+			let l:tree = import_tree#BuildFromBuffer(v:true)
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.io.IOException'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.List'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.Collections'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'ca.example.vim.internal.ImportedClass'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'ca.example.vim.external.Interface'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'javax.servlet.FilterChain'))
+		End
+	End
+
+	Describe #BuildFromStatements
+		It should correctly build an import from the given statements
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;'
+				\ ]
+
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			Assert True(test_utils#tree#HasNode(l:tree, 'javax.servlet.FilterChain'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.List'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.Collections'))
+		End
+
+		It should correctly set metadata for static imports
+			let l:stmt = 'import static ca.example.vim.Util.staticMethod;'
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+
+			Assert True(test_utils#tree#HasNode(l:tree, 'ca.example.vim.Util.staticMethod'))
+			let [_, l:meta] = test_utils#tree#GetMetadataForNode(l:tree, 'ca.example.vim.Util.staticMethod')
+			Assert True(has_key(l:meta, 's'))
+			Assert True(l:meta.s)
+		End
+
+		It should correctly set metadata for non-static imports
+			let l:stmt = 'import java.util.List;'
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.List'))
+			let [_, l:meta] = test_utils#tree#GetMetadataForNode(l:tree, 'java.util.List')
+			Assert True(has_key(l:meta, 's'))
+			Assert False(l:meta.s)
+		End
+
+		It should create a tree with the correct internal structure
+			let l:stmt = 'import java.util.List;'
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+
+			" level 1
+			Assert True(has_key(l:tree, 'children'))
+			Assert True(has_key(l:tree, 'leaf'))
+			Assert False(len(l:tree.leaf))
+
+			" children at level 1
+			Assert Equal(len(l:tree.children), 1)
+			Assert True(has_key(l:tree.children, 'java'))
+
+			" level 2
+			Assert True(has_key(l:tree.children.java, 'children'))
+			Assert True(has_key(l:tree.children.java, 'leaf'))
+			Assert False(len(l:tree.children.java.leaf))
+
+			" children at level 2
+			Assert Equal(len(l:tree.children.java.children), 1)
+			Assert True(has_key(l:tree.children.java.children, 'util'))
+
+			" level 3
+			Assert True(has_key(l:tree.children.java.children.util, 'children'))
+			Assert True(has_key(l:tree.children.java.children.util, 'leaf'))
+			Assert Equal(len(l:tree.children.java.children.util.children), 0)
+
+			" leafs at level 3
+			Assert Equal(len(l:tree.children.java.children.util.leaf), 1)
+			Assert True(has_key(l:tree.children.java.children.util.leaf, 'List'))
+		End
+
+		It should filter whitespace properly
+			let l:stmt = '     import 	 java  . util.List   ; '
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.List'))
+		End
+
+		It should split compound statements
+			let l:stmt = 'import javax.servlet.FilterChain; import java.util.Collections;'
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.Collections'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'javax.servlet.FilterChain'))
+		End
+
+		It should correctly insert wildcard imports
+			let l:stmt = 'import java.util.*;'
+			let l:tree = import_tree#BuildFromStatements([l:stmt])
+
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.*'))
+		End
+
+		It should throw error if statement is invalid
+			Throws /unexpected statement/ import_tree#BuildFromStatements(['import static ;'])
+			Throws /invalid import statement/ import_tree#BuildFromStatements(['import java.util.1List'])
+			Throws /unexpected statement/ import_tree#BuildFromStatements(['imports static java.util.List'])
+			Throws /unexpected statement/ import_tree#BuildFromStatements(['static java.util.List'])
+			Throws /unexpected statement/ import_tree#BuildFromStatements(['import java.util.List;i'])
+		End
+	End
+
 	Describe #Merge
 		Before
 			%bwipeout!
 		End
 
-		It should merge a fully-qualified class name into the given tree
-			edit test/input/StaticImports.java
+		It should insert a fully-qualified entity into the tree
+			edit! test/input/Simple.java
 
-			let l:trees = import_tree#Build()
-			call import_tree#Merge(l:trees, 'ca.example.mytest.MyTestClass')
+			let l:tree = import_tree#BuildFromBuffer(v:false)
+			call import_tree#Merge(l:tree, 'com.example.vim.thing')
 
-			Assert True(has_key(l:trees.ns.ca.example.mytest, 'MyTestClass'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'com.example.vim.thing'))
 		End
 
-		It should merge a fully-qualified static method name into the given tree if instructed
-			edit test/input/StaticImports.java
+		It should create the tree node with the given metadata
+			edit! test/input/Simple.java
 
-			let l:trees = import_tree#Build()
-			call import_tree#Merge(l:trees, 'ca.example.mytest.MyTestClass.myStaticMethod', v:true)
+			let l:tree = import_tree#BuildFromBuffer(v:false)
+			call import_tree#Merge(l:tree, 'com.example.vim.thing', { 'my-metadata': v:true })
 
-			Assert True(has_key(l:trees.s.ca.example.mytest.MyTestClass, 'myStaticMethod'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'com.example.vim.thing'))
+			let [_, l:meta] = test_utils#tree#GetMetadataForNode(l:tree, 'com.example.vim.thing')
+			
+			Assert True(has_key(l:meta, 'my-metadata'))
+			Assert Equals(l:meta['my-metadata'], v:true)
 		End
 	End
 
@@ -32,91 +166,144 @@ Describe import_tree
 			let g:java_import_wildcard_count = 0
 		End
 
-		It should flatten the trees into a flat list of imports with a specific prefix and postfix
-			let l:mock_tree = {
-				\ 'ca': { 'example': { 'MyClass': {}, 'MySecondClass': {} } },
-				\ }
+		It should flatten a simple tree to a list of unique identifiers
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;',
+					\ 'import java.util.List;'
+				\ ]
 
-			let l:result = import_tree#Flatten(l:mock_tree, [], 'pre#', '#post')
-			Assert Equals(len(l:result), 2)
-			Assert True(match(l:result, 'pre#ca.example.MyClass#post') >= 0)
-			Assert True(match(l:result, 'pre#ca.example.MySecondClass#post') >= 0)
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree)
+			
+			Assert Equals(len(l:result), 3)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, 'java.util.Collections') >= 0)
+			Assert True(index(l:result, 'java.util.List') >= 0)
 		End
 
-		It should remove wildcard leaf nodes if configured
+		It should prepend the prefix to each returned value
+			let l:tree = import_tree#BuildFromStatements(['import javax.servlet.FilterChain;'])
+			let l:result = import_tree#Flatten(l:tree, { 'prefix': '$' })
+			
+			Assert Equals(len(l:result), 1)
+			Assert True(index(l:result, '$javax.servlet.FilterChain') >= 0)
+		End
+
+		It should append the postfix to each returned value
+			let l:tree = import_tree#BuildFromStatements(['import javax.servlet.FilterChain;'])
+			let l:result = import_tree#Flatten(l:tree, { 'postfix': '$' })
+			
+			Assert Equals(len(l:result), 1)
+			Assert True(index(l:result, 'javax.servlet.FilterChain$') >= 0)
+		End
+
+		It should correctly filter elements by their metadata if configured
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import static java.util.Collections;',
+					\ 'import java.util.List;'
+				\ ]
+
+			" with static filter
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree, { 'filter': { 's': v:true } })
+			
+			Assert Equals(len(l:result), 1)
+			Assert True(index(l:result, 'java.util.Collections') >= 0)
+
+			" now with non-static
+			let l:result = import_tree#Flatten(l:tree, { 'filter': { 's': v:false } })
+			
+			Assert Equals(len(l:result), 2)
+			Assert True(index(l:result, 'java.util.List') >= 0)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+		End
+
+		It should use the provided initial list if configured
+			let l:initial = ['test123']
+			let l:tree = import_tree#BuildFromStatements(['import javax.servlet.FilterChain;'])
+			let l:result = import_tree#Flatten(l:tree, { 'initial': l:initial })
+			
+			Assert Equals(len(l:result), 2)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, l:initial[0]) >= 0)
+		End
+
+		It should remove wildcard nodes if configured
 			let g:java_import_wildcard_count = -1
 
-			let l:mock_tree = {
-				\ 'ca': { 'example': { '*': {}, 'MySecondClass': {} } },
-				\ }
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;',
+					\ 'import java.util.*;'
+				\ ]
 
-			let l:result = import_tree#Flatten(l:mock_tree, [], '', '')
-			Assert Equals(len(l:result), 1)
-			Assert True(match(l:result, 'ca.example.MySecondClass') >= 0)
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree)
+			
+			Assert Equals(len(l:result), 3)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, 'java.util.Collections') >= 0)
+			Assert True(index(l:result, 'java.util.List') >= 0)
 		End
 
-		It should merge leaf nodes into existing wildcard nodes if configured
+		It should merge leafs into wildcard nodes if configured
 			let g:java_import_wildcard_count = 0
 
-			let l:mock_tree = {
-				\ 'ca': { 'example': { '*': {}, 'MySecondClass': {} } },
-				\ }
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;',
+					\ 'import java.util.*;'
+				\ ]
 
-			let l:result = import_tree#Flatten(l:mock_tree, [], '', '')
-			Assert Equals(len(l:result), 1)
-			Assert True(match(l:result, 'ca.example.*') >= 0)
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree)
+			
+			Assert Equals(len(l:result), 2)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, 'java.util.*') >= 0)
 		End
 
-		It should merge leaf nodes if count is greater than configured value
-			let g:java_import_wildcard_count = 4
-
-			let l:mock_tree = {
-					\ 'ca': {
-						\ 'example': {
-							\ 'MyClass': {},
-							\ 'MySecondClass': {},
-							\ 'MyThirdClass': {},
-							\ 'mypackage': {
-								\ 'MyClass': {}
-							\ }
-						\ }
-					\ }
-				\ }
-
-			let l:result = import_tree#Flatten(l:mock_tree, [], '', '')
-			Assert Equals(len(l:result), 4)
-
+		It should merge leafs nodes into wildcards if the number of leafs exceed configured value
 			let g:java_import_wildcard_count = 3
 
-			let l:result = import_tree#Flatten(l:mock_tree, [], '', '')
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;',
+					\ 'import java.util.Arrays;'
+				\ ]
+
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree)
+			
 			Assert Equals(len(l:result), 2)
-			Assert True(match(l:result, 'ca.example.*') >= 0)
-			Assert True(match(l:result, 'ca.example.mypackage.MyClass') >= 0)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, 'java.util.*') >= 0)
+
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;'
+				\ ]
+
+			let l:tree = import_tree#BuildFromStatements(l:statements)
+			let l:result = import_tree#Flatten(l:tree)
+			
+			Assert Equals(len(l:result), 3)
+			Assert True(index(l:result, 'javax.servlet.FilterChain') >= 0)
+			Assert True(index(l:result, 'java.util.Collections') >= 0)
+			Assert True(index(l:result, 'java.util.List') >= 0)
 		End
-	End
 
-	Describe #Build
-		Before
-			%bwipeout!
-		End
-
-		It should build trees correctly
-			edit test/input/StaticImports.java
-
-			let l:imports = buffer#FindLinesMatchingPattern(1, 'import')
-			let l:initial_linecount = line('$')
-
-			let l:trees = import_tree#Build()
-			Assert Equals(line('$'), l:initial_linecount - len(l:imports))
-
-			Assert True(has_key(l:trees.s.ca.example.vim.Util, 'staticMethod'))
-			Assert True(has_key(l:trees.ns.java.io, 'IOException'))
-			Assert True(has_key(l:trees.ns.java.util, 'List'))
-			Assert True(has_key(l:trees.ns.java.util, 'Collections'))
-			Assert True(has_key(l:trees.ns.ca.example.vim.internal, 'ImportedClass'))
-			Assert True(has_key(l:trees.ns.ca.example.vim.internal, 'ImportedClass'))
-			Assert True(has_key(l:trees.ns.ca.example.vim.external, 'Interface'))
-			Assert True(has_key(l:trees.ns.javax.servlet, 'FilterChain'))
+		It should throw if options has an unexpected key
+			let l:tree = import_tree#BuildFromStatements([])
+			Throws /not a supported option/ import_tree#Flatten(l:tree, { '_path': [] })
 		End
 	End
 End
+

--- a/test/util/autoload/test_utils/tree.vim
+++ b/test/util/autoload/test_utils/tree.vim
@@ -1,0 +1,29 @@
+" Check if the tree `tree` has a node at `path`. Returns v:true if the node
+" exists, otherwise returns v:false.
+function! test_utils#tree#HasNode(tree, path)
+	return len(test_utils#tree#GetMetadataForNode(a:tree, a:path)) ? v:true : v:false
+endfunction
+
+" Get the metadata associated with a node in `tree` at path `path`.
+" Return a tuple [<leaf node name>, <leaf metadata>]
+function! test_utils#tree#GetMetadataForNode(tree, path)
+	let l:cmps = split(a:path, '\.')
+	let l:leading = l:cmps[0:-2]
+	let l:leaf = l:cmps[-1]
+
+	let l:node = a:tree
+	for cmp in l:leading
+		if !has_key(l:node, 'children') || !has_key(l:node.children, cmp)
+			return []
+		endif
+
+		let l:node = l:node.children[cmp]
+	endfor
+
+	if !has_key(l:node, 'leaf') || !has_key(l:node.leaf, l:leaf)
+		return []
+	endif
+
+	return [l:leaf, l:node.leaf[l:leaf]]
+endfunction
+


### PR DESCRIPTION
In the rare case the class name (and all of its package components) of an
import statement was the same as the package for another import, the
first import would get merged into the second incorrectly. This was a
function of how imports were represented internally.

For instance, the import `ca.example.Class` would get merged into the
import `ca.example.Class.OtherClass`.

To address this, the import statement structure was reworked to handle
such cases.

Fixes #15
Fixes #5