### PR TITLE
silence messages while importing class

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ like whether it's a class or enum).
 
 You can add a mapping to make your life a bit easier:
 ```vim
-nnoremap <silent> <leader>jo :JavaSortImports<CR>
-nnoremap <silent> <leader>ji :JavaImportKeyword<CR>
+nnoremap <silent> <C-i> :JavaImportKeyword<CR>
+nnoremap <silent> <leader>jo :JavaImportSort<CR>
 nnoremap <silent> <leader>jc :JavaImportIndex<CR>
 ```
 

--- a/autoload/java_support/import.vim
+++ b/autoload/java_support/import.vim
@@ -12,12 +12,6 @@ function! java_support#import#JavaImportKeyword(keyword = '') abort
 		return
 	endif
 
-	if empty(tagfiles())
-		echohl WarningMsg |
-			\ echo 'java-support.vim: cannot import class: missing a tag file' |
-			\ echohl None
-	endif
-
 	let l:keyword = a:keyword ? a:keyword : s:GetKeywordUnderCursor()
 	if l:keyword == ''
 		return
@@ -131,8 +125,6 @@ function! s:ImportClass(tag_result) abort
 	let l:trees = java_support#import_tree#BuildFromBuffer('%', v:true)
 	call java_support#import_tree#Merge(l:trees, a:tag_result.fq_name, { 's': a:tag_result.s })
 	call java_support#sort#JavaSortImportsTrees(l:trees)
-
-	echo 'imported "' . join(a:tag_result.fq_name, '.') . '"'
 endfunction
 
 " Fetch import suggestion results from tags and from the index (if enabled).


### PR DESCRIPTION
When relying only on indexing features, a warning message is shown when importing classes. This leads to poor UX, since the user needs to press enter to suppress the messages.

This warning message has been removed.