### PR TITLE
sort imports when nothing to import

### DIFF
--- a/autoload/java_support/import.vim
+++ b/autoload/java_support/import.vim
@@ -3,6 +3,8 @@
 " If a keyword is provided as a function argument, the first result is
 " imported. Otherwise, a popup menu is shown allowing the user to select which
 " class to import.
+" If 'keyword' is empty and <cword> expands to empty, the imports in the
+" current buffer are sorted.
 function! java_support#import#JavaImportKeyword(keyword = '') abort
 	" ensure this is a java file
 	if &filetype != 'java'
@@ -14,6 +16,7 @@ function! java_support#import#JavaImportKeyword(keyword = '') abort
 
 	let l:keyword = a:keyword ? a:keyword : s:GetKeywordUnderCursor()
 	if l:keyword == ''
+		call java_support#sort#JavaSortImports()
 		return
 	endif
 
@@ -96,10 +99,6 @@ function! s:ImportFromSelection(keyword, tag_results) abort
 		elseif a:key == 'h' || a:key == "\<Left>"
 			let l:state = s:RotatePopupEntries(a:id, l:state - 1, a:tag_results)
 			return 1
-		elseif a:key == 'j'
-			return popup_filter_menu(a:id, "\<Down>")
-		elseif a:key == 'k'
-			return popup_filter_menu(a:id, "\<Up>")
 		elseif a:key == "\<Tab>"
 			return popup_filter_menu(a:id, "\<CR>")
 		else

--- a/test/integration/import.vimspec
+++ b/test/integration/import.vimspec
@@ -1,0 +1,28 @@
+Describe Import
+	After
+		%bwipeout!
+	End
+
+	Describe #JavaImportKeyword
+		It should sort imports if no classname provided and no keyword under cursor
+			edit! test/input/Simple.java
+
+			" position the cursor at the end of the file so that <cword> expands
+			" to empty string
+			call cursor(line('$'), 0)
+
+			" sanity check
+			Assert Equals(expand('<cword>'), '')
+
+			call java_support#import#JavaImportKeyword()
+
+			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import')
+			Assert Equals(len(l:import_lines), 2)
+
+			" should have sorted
+			Assert Equals(l:import_lines[0], 'import ca.example.vim.external.Interface;')
+			Assert Equals(l:import_lines[1], 'import ca.example.vim.internal.ImportedClass;')
+		End
+	End
+End
+


### PR DESCRIPTION
When importing classes, if no explicit keyword is given and <cword> expands to the empty string, simply sort import statements in the current buffer. This is handy because it avoids the need for an additional mapping for sorting imports; instead, navigate to an empty line and run an import.

A simple test has been introduced for this behaviour.

Additionally, some branches in the popup filter callback for the import functionality were redundant and mimic native behaviour. These branches have been removed.