### PR TITLE
sort import suggestions

### DIFF
--- a/autoload/java_support/index.vim
+++ b/autoload/java_support/index.vim
@@ -9,20 +9,15 @@
 " traversal from the cwd.
 function! java_support#index#Load(save, recover, buffer = v:null) abort
 	if !g:java_import_index_enable
-		echohl WarningMsg |
-			\ echo 'java-support.vim: indexing features are disabled' |
-			\ echohl None
-		return
+		return java_support#util#Warn('indexing features are disabled')
 	endif
 
 	" lmake sure the index file exists
 	let l:index_file_path = g:java_import_index_path . '/.idx'
 	if !empty(g:java_import_index_path)
 		if !mkdir(g:java_import_index_path, "p")
-			echohl WarningMsg |
-				\ echo 'java-support.vim: failed to create index save location "' . g:java_import_index_path . '"' |
-				\ echohl None
-			return
+			return java_support#util#Warn('failed to create index save location "'
+				\ . g:java_import_index_path . '"')
 		endif
 
 		" create the file
@@ -30,10 +25,7 @@ function! java_support#index#Load(save, recover, buffer = v:null) abort
 	endif
 
 	if a:save && empty(g:java_import_index_path)
-		echohl WarningMsg |
-			\ echo 'java-support.vim: index file location unset (g:java_import_index_save)' |
-			\ echohl None
-		return
+		return java_support#util#Warn('index file location unset (g:java_import_index_save)')
 	endif
 
 	let l:progress_handle = java_support#progress#Show()
@@ -64,10 +56,7 @@ endfunction
 " if configured (clears the cache).
 function! java_support#index#Reset(save) abort
 	if a:save && empty(g:java_import_index_path)
-		echohl WarningMsg |
-			\ echo 'java-support.vim: index file location unset (g:java_import_index_save)' |
-			\ echohl None
-		return
+		return java_support#util#Warn('index file location unset (g:java_import_index_save)')
 	endif
 
 	call s:CommitIndexTree(java_support#import_tree#BuildEmpty(),

--- a/autoload/java_support/sort.vim
+++ b/autoload/java_support/sort.vim
@@ -28,10 +28,7 @@ endfunction
 function! java_support#sort#JavaSortImports() abort
 	" ensure this is a java file
 	if &filetype != 'java'
-		echohl WarningMsg |
-			\ echo 'java-support.vim: cannot sort imports: unexpected filetype "' . &filetype . '"' |
-			\ echohl None
-		return
+		return java_support#util#Warn('cannot sort imports: unexpected filetype "' . &filetype . '"')
 	endif
 
 	call java_support#sort#JavaSortImportsTrees(java_support#import_tree#BuildFromBuffer('%', v:true))

--- a/autoload/java_support/util.vim
+++ b/autoload/java_support/util.vim
@@ -101,3 +101,10 @@ function! s:InvokeUnlessIgnored(file_path, callback)
 	call a:callback(a:file_path)
 endfunction
 
+" Print a warning message.
+function! java_support#util#Warn(message) abort
+	echohl WarningMsg |
+		\ echo 'java-support.vim: ' . a:message |
+		\ echohl None
+endfunction
+

--- a/test/integration/import.vimspec
+++ b/test/integration/import.vimspec
@@ -24,5 +24,47 @@ Describe Import
 			Assert Equals(l:import_lines[1], 'import ca.example.vim.internal.ImportedClass;')
 		End
 	End
+
+	Describe #ResultComparator
+		It should sort results by kind
+			let l:results = [
+				\ { 'type': 'indexed', 'val': 9 },
+				\ { 'type': 'c', 'val': 0 },
+				\ { 'type': 'm', 'val': 8 },
+				\ { 'type': 'c', 'val': 1 },
+				\ { 'type': 'e', 'val': 6 },
+				\ { 'type': 'g', 'val': 5 },
+				\ { 'type': 'e', 'val': 7 },
+				\ { 'type': 'a', 'val': 4 },
+				\ { 'type': 'i', 'val': 3 },
+				\ { 'type': 'indexed', 'val': 10 },
+				\ { 'type': 'unknown', 'val': 11 },
+				\ { 'type': 'c', 'val': 2 },
+			\ ]
+
+			let l:sorted = sort(l:results, function('java_support#import#ResultComparator'))
+			for i in range(len(l:results))
+				Assert Equals(l:sorted[i]['val'], i)
+			endfor
+		End
+	End
+
+	Describe #MergeFilterDuplicateResults
+		It should filter indexed results that exist in the tag results
+			let l:results = [
+				\ { 'fq_name': ['com', 'example', 'vim'] },
+				\ { 'fq_name': ['com', 'example', 'vim1'] },
+			\ ]
+			let l:index_results = [
+				\ { 'fq_name': ['com', 'example', 'vim1'] },
+			\ ]
+
+			let l:filtered = java_support#import#MergeFilterDuplicateResults(l:results, l:index_results)
+			Assert Equals(len(l:filtered), 2)
+			for i in range(len(l:filtered))
+				Assert Equals(l:filtered[i].fq_name, l:results[i].fq_name)
+			endfor
+		End
+	End
 End
 


### PR DESCRIPTION
Classes, interfaces and enums are imported more often than static methods. Furthermore, indexed imports might not offer the best results, so they should appear after all tag results.

To improve this, results are sorted by their kind. This ensures most relevant results appear first. Additionally, results from the index are filtered if they already exist in the tag results.