### PR TITLE
rework plugin commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,33 +19,37 @@ Plug 'brandon1024/java-support.vim'
 ```
 
 ## Usage
-To sort import statements in the current buffer:
-```vim
-:JavaSortImports
+To cleanup import statements:
+```
+:Java cleanup-imports
 ```
 
-To import a class under the current keyword (or a specific class):
-```vim
-:JavaImportKeyword
-:JavaImportKeyword MyClass
+To import a class or enum with a specific name:
+```
+:Java import MyClass
 ```
 
-To index Java files from your project (cwd):
-```vim
-:JavaImportIndex
+To import a class or enum with a name under the cursor:
+```
+:Java import
 ```
 
-The class import functionality relies on the existence of a tags file. The tags
-file can be generated with a tool like
+To re-index (cache) references from imports in the current project (cwd):
+```
+:Java index
+```
+
+This plugin uses tag files to locate classes and build fully-qualified class
+names. Without it, import features will be limited. The tags file can be
+generated with a tool like
 [universal-ctags](https://github.com/universal-ctags/ctags). The ctags
 generator must smart enough to read Java files correctly (including metadata
 like whether it's a class or enum).
 
 You can add a mapping to make your life a bit easier:
 ```vim
-nnoremap <silent> <C-i> :JavaImportKeyword<CR>
-nnoremap <silent> <leader>jo :JavaImportSort<CR>
-nnoremap <silent> <leader>jc :JavaImportIndex<CR>
+nnoremap <silent> <C-i> :Java import<CR>
+nnoremap <silent> <leader>jc :Java index<CR>
 ```
 
 ## Configuration

--- a/autoload/java_support/plugin.vim
+++ b/autoload/java_support/plugin.vim
@@ -1,0 +1,26 @@
+" Entrypoint for the plugin.
+function! java_support#plugin#Command(cmd, ...) abort
+	if a:cmd == 'import'
+		call java_support#import#JavaImportKeyword(a:0 == 1 ? a:1 : '')
+	elseif a:cmd == 'cleanup-imports'
+		call java_support#sort#JavaSortImports()
+	elseif a:cmd == 'index'
+		if a:0 == 0
+			return java_support#index#IndexDirectory()
+		endif
+
+		let l:subcommand = a:1
+		if l:subcommand == 'buffer'
+			call java_support#index#IndexBuffer(a:0 == 1 ? a:1 : '')
+		elseif l:subcommand == 'dir'
+			call java_support#index#IndexDirectory(a:0 == 1 ? a:1 : '')
+		elseif l:subcommand == 'save'
+			call java_support#index#Save()
+		elseif l:subcommand == 'recover'
+			call java_support#index#Recover()
+		elseif l:subcommand == 'clear'
+			call java_support#index#Clear()
+		endif
+	endif
+endfunction
+

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -68,37 +68,38 @@ USAGE                                                       |java-support-usage|
 
 To cleanup import statements:
 >
-	:JavaImportSort
+	:Java cleanup-imports
 <
 
 To import a class or enum with a specific name:
 >
-	:JavaImportKeyword MyClass
+	:Java import MyClass
 <
 
 To import a class or enum with a name under the cursor:
 >
-	:JavaImportKeyword
+	:Java import
 <
 
-To re-index (cache) references from imports in the current project:
+To re-index (cache) references from imports in the current project (cwd):
 >
-	:JavaImportIndex
+	:Java index
 <
 
 --------------------------------------------------------------------------------
 COMMANDS                                                 *java-support-commands*
 
-                                                               *:JavaImportSort*
-:JavaImportSort
+                                                                         *:Java*
+:Java cleanup-imports
 	Clean up import statements in the current buffer. Import statements are
 	removed, optimized, sorted, and then written to the buffer just below the
 	package statement (if exists).
 
-                                                            *:JavaImportKeyword*
-:JavaImportKeyword [{name}]
-	Search tag files for classes and enums with a specific [name]. If [name] is
-	given, searches for classes with that name. If [name] is omitted, searches
+:Java import [{name}]
+	Import a class and cleanup the imports.
+
+	Search tag files for classes and enums with a specific {name}. If {name} is
+	given, searches for classes with that name. If {name} is omitted, searches
 	for classes with a name under the cursor (<cword>).
 
 	If there are multiple results, a popup menu is shown allowing the user to
@@ -106,33 +107,34 @@ COMMANDS                                                 *java-support-commands*
 	and k/<Up> keys select a result. You can also use h/<Left> and l/<Right> to
 	show additional information.
 
-                                                              *:JavaImportIndex*
-:JavaImportIndex[!] [{buffer}]
-	Index references from Java files in the current project.
+	If there's nothing under the cursor (<cword> expands to ''), the import
+	statements are sorted (equivalent to running 'cleanup-imports').
 
-	Indexing will help offer better import suggestions by offering classes
-	that have been imported elsewhere in a project. The index is not created
-	automatically at startup; you'll need to plumb that yourself. In large
-	projects, indexing may take a while to complete.
+:Java index [{subcommand} [{arg}]]
+	Manipulate the index. Indexing will help offer better import suggestions by
+	offering classes that have been imported elsewhere in a project. The index
+	is not created automatically at startup; you'll need to plumb that
+	yourself. In large projects, indexing may take a while to complete.
 
-	If {buffer} is given, imports from that buffer are merged into the index.
-	Otherwise, Java files are read through directory traversal (from the cwd)
-	and merged into the index. With a bang "!", the index is written to the
-	index file (see |g:java_import_index_path|).
+	Without any {subcommand} or {arg}, the 'dir' subcommand is assumed,
+	starting at the current working directory.
 
-	When indexing through directory traversal, 'wildignore' is respected.
+	If {subcommand} is 'buffer', imports from the buffer {arg} are merged into
+	the index. If {arg} is omitted, imports are read from the current buffer
+	'%'.
 
-                                                       *:JavaImportIndexRecover*
-:JavaImportIndexRecover[!]
-	Recover and populate the index from the index file
-	|g:java_import_index_path|, if configured. The index from the file is
-	merged into the existing index. With a bang "!", the index file is written
-	to a index file.
+	If {subcommand} is 'dir', Java files are read through recursive directory
+	traversal starting from directory {arg} and merged into the index. If {arg}
+	is omitted, the current working directory is used. 'wildignore' is
+	respected.
 
-                                                         *:JavaImportIndexReset*
-:JavaImportIndexReset[!]
-	Clear the index. With a bang "!", the index file |g:java_import_index_path|
-	is also cleared.
+	If {subcommand} is 'save', the index is written to the file
+	|g:java_import_index_path|.
+
+	If {subcommand} is 'recover', the index is read from the file
+	|g:java_import_index_path| and merged into the index.
+
+	If {subcommand} is 'clear', the index is cleared.
 
 ================================================================================
 OPTIONS                                                   *java-support-options*
@@ -223,16 +225,6 @@ There are no import options at this time.
 --------------------------------------------------------------------------------
 INDEX OPTIONS                                       *java-support-index-options*
 
-                                                  *'g:java_import_index_enable'*
-Enable or disable indexing features. When enabled, the plugin can scan and
-index Java files to offer better import suggestions. When disabled, indexing
-features are not used.
-
-Default:
->
-	let g:java_import_index_enable = 1
-<
-
                                                 *'g:java_import_index_progress'*
 Enable or disable progress information when indexing. When enabled, a popup is
 shown in the bottom right corner to show which files are being indexed.
@@ -249,7 +241,7 @@ saved and must be recreated in each new session.
 
 Default:
 >
-	let g:java_import_index_path = $HOME . '.cache/java-support'
+	let g:java_import_index_path = $HOME . '.cache/java-support/.idx'
 <
 
 ================================================================================
@@ -261,9 +253,8 @@ CREATING CUSTOM MAPPINGS                 *java-support-creating-custom-mappings*
 Key mappings are not created by default, but you can add them if you wish. Here
 are some mappings that I use:
 >
-	nnoremap <silent> <leader>jo :JavaImportSort<CR>
-	nnoremap <silent> <leader>ji :JavaImportKeyword<CR>
-	nnoremap <silent> <leader>jc :JavaImportIndex<CR>
+	nnoremap <silent> <C-i> :Java import<CR>
+	nnoremap <silent> <leader>jc :Java index<CR>
 <
 
 The possibilities don't end there. If you are feeling bold, you could
@@ -307,7 +298,7 @@ Dependence on ctags~
 UNIVERSAL CTAGS                                   *java-support-universal-ctags*
 
 This plugin uses tag files to locate classes and build fully-qualified class
-names. Without it, auto import features will be limited. If you haven't worked
+names. Without it, import features will be limited. If you haven't worked
 with *universal-ctags* before, it'll change your life. It's also pretty easy to
 use. I'll give a bit of information in this section, but you should definitely
 read through the ctags documentation for a more comprehensive overview.

--- a/plugin/java_support.vim
+++ b/plugin/java_support.vim
@@ -25,11 +25,6 @@ if !exists('g:java_import_wildcard_count')
 	let g:java_import_wildcard_count = 0
 endif
 
-" By default, enable indexing features.
-if !exists('g:java_import_index_enable')
-	let g:java_import_index_enable = 1
-endif
-
 " By default, enable indexing progress.
 if !exists('g:java_import_index_progress')
 	let g:java_import_index_progress = 1
@@ -38,12 +33,8 @@ endif
 " By default, when saving and loading an index, it's read from
 " ${HOME}/.cache/java-support/.idx
 if !exists('g:java_import_index_path')
-	let g:java_import_index_path = $HOME . '/.cache/java-support'
+	let g:java_import_index_path = $HOME . '/.cache/java-support/.idx'
 endif
 
-command! JavaImportSort call java_support#sort#JavaSortImports()
-command! -nargs=? JavaImportKeyword call java_support#import#JavaImportKeyword(<f-args>)
-command! -nargs=? -bang JavaImportIndex call java_support#index#Load(<bang>v:false, v:false, <f-args>)
-command! -bang JavaImportIndexRecover call java_support#index#Load(<bang>v:false, v:true)
-command! -bang JavaImportIndexReset call java_support#index#Reset(<bang>v:false)
+command! -nargs=* Java call java_support#plugin#Command(<f-args>)
 


### PR DESCRIPTION
Rather than introduce multiple commands for each feature supported by the plugin, we now only introduce a single command :Java that acts as an entrypoint for the plugin.

The indexing features were reworked a bit to make them a bit simpler.

The :Java command doesn't support completion features yet, but this will be introduced in a later revision.