### PR TITLE
insert local variable declaration

### DIFF
--- a/autoload/java_support/plugin.vim
+++ b/autoload/java_support/plugin.vim
@@ -21,6 +21,8 @@ function! java_support#plugin#Command(cmd, ...) abort
 		elseif l:subcommand == 'clear'
 			call java_support#index#Clear()
 		endif
+	elseif a:cmd == 'insert-var'
+		call java_support#templates#InsertLocalVariable()
 	endif
 endfunction
 

--- a/autoload/java_support/templates.vim
+++ b/autoload/java_support/templates.vim
@@ -1,0 +1,23 @@
+" Insert a local variable declartion and assignment on the current line.
+function! java_support#templates#InsertLocalVariable() abort
+	if &filetype != 'java'
+		return java_support#util#Warn('cannot insert variable declaration: unexpected filetype "' . &filetype . '"')
+	endif
+
+	let l:lnum = line('.')
+	let l:ltext = getline(l:lnum)
+
+	" find index of first non-whitespace character, or zero if no whitespace
+	let l:start = max([match(l:ltext, '\w'), 0])
+
+	" prepend with 'final'
+	let l:declr = g:java_insert_var_declare_final ? 'final ' : ''
+
+	" insert declaration at start of line
+	let l:before_cursor = l:ltext[:l:start - 1] . l:declr . 'var '
+	let l:after_cursor = ' = ' . l:ltext[l:start:]
+
+	call setline(l:lnum, l:before_cursor . l:after_cursor)
+	call cursor(l:lnum, len(l:before_cursor) + 1)
+endfunction
+

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -14,6 +14,7 @@ OPTIONS                                                   |java-support-options|
   SORT OPTIONS                                       |java-support-sort-options|
   IMPORT OPTIONS                                   |java-support-import-options|
   INDEX OPTIONS                                     |java-support-index-options|
+  MISC OPTIONS                                       |java-support-misc-options|
 MAPPINGS                                                 |java-support-mappings|
   CREATING CUSTOM MAPPINGS               |java-support-creating-custom-mappings|
 EXTRA                                                       |java-support-extra|
@@ -58,10 +59,13 @@ Optimize/Merge Import Statements~
 	Remove duplicate or unecessary import statements. Automatically merge
 	same-package imports into a single wildcard import (when enabled).
 
-Class/Interface/Enum/Method Auto Import~
+Class/Interface/Enum/Method Import~
 	Import project classes, interfaces, enums and static methods by name with
 	the help of tag files. Intelligently index imported classes found in Java
 	project files, offering suggestions for classes not found in tag files.
+
+Introduce Local Variable Declaration~
+	Insert a local variable declaration under the cursor.
 
 ================================================================================
 USAGE                                                       |java-support-usage|
@@ -84,6 +88,11 @@ To import a class or enum with a name under the cursor:
 To re-index (cache) references from imports in the current project (cwd):
 >
 	:Java index
+<
+
+To insert a local variable declaration under the current line:
+>
+	:Java insert-var
 <
 
 --------------------------------------------------------------------------------
@@ -135,6 +144,16 @@ COMMANDS                                                 *java-support-commands*
 	|g:java_import_index_path| and merged into the index.
 
 	If {subcommand} is 'clear', the index is cleared.
+
+:Java insert-var
+	Insert a local variable declaration and assignment at the beginning of the
+	line, placing the cursor at the variable name. This will insert 'final var
+	= ' at the beginning of the line.
+
+	This plugin does not know anything about the lexical structure of Java
+	source code. It knows nothing about your Java version, nor does it have any
+	knowledge of any types. This is merely a convenience feature for Java 11+
+	sources, leveraging type inference features ('var' keyword).
 
 ================================================================================
 OPTIONS                                                   *java-support-options*
@@ -244,6 +263,18 @@ Default:
 	let g:java_import_index_path = $HOME . '.cache/java-support/.idx'
 <
 
+--------------------------------------------------------------------------------
+MISC OPTIONS                                         *java-support-misc-options*
+
+                                             *'g:java_insert_var_declare_final'*
+When inserting local variable declarations, configure whether to create variable
+as 'final'.
+
+Default:
+>
+	let g:java_insert_var_declare_final = 1
+<
+
 ================================================================================
 MAPPINGS                                                 *java-support-mappings*
 
@@ -255,6 +286,8 @@ are some mappings that I use:
 >
 	nnoremap <silent> <C-i> :Java import<CR>
 	nnoremap <silent> <leader>jc :Java index<CR>
+	nnoremap <silent> <F5> :Java insert-var<CR>
+	inoremap <silent> <F5> <C-o>:Java insert-var<CR>
 <
 
 The possibilities don't end there. If you are feeling bold, you could

--- a/plugin/java_support.vim
+++ b/plugin/java_support.vim
@@ -36,5 +36,10 @@ if !exists('g:java_import_index_path')
 	let g:java_import_index_path = $HOME . '/.cache/java-support/.idx'
 endif
 
+" By default, make all variable declarations 'final'.
+if !exists('g:java_insert_var_declare_final')
+	let g:java_insert_var_declare_final = 1
+endif
+
 command! -nargs=* Java call java_support#plugin#Command(<f-args>)
 

--- a/test/input/InsertVariable.java
+++ b/test/input/InsertVariable.java
@@ -1,0 +1,7 @@
+public class InsertVariable {
+
+    protected HttpResponse<String> send(final HttpRequest.Builder requestPrototype) throws IOException, InterruptedException {
+        prepareHeader(copy(), value)
+                .build();
+    }
+}

--- a/test/input/tags
+++ b/test/input/tags
@@ -1,14 +1,12 @@
 !_TAG_FILE_FORMAT	2	/extended format; --format=1 will not append ;" to lines/
 !_TAG_FILE_SORTED	1	/0=unsorted, 1=sorted, 2=foldcase/
-!_TAG_OUTPUT_EXCMD	mixed	/number, pattern, mixed, or combineV2/
 !_TAG_OUTPUT_FILESEP	slash	/slash or backslash/
 !_TAG_OUTPUT_MODE	u-ctags	/u-ctags or e-ctags/
 !_TAG_PATTERN_LENGTH_LIMIT	96	/0 for no limit/
-!_TAG_PROC_CWD	/Users/brandon/.dotfiles/.vim/pack/plugins/opt/java-support.vim/	//
 !_TAG_PROGRAM_AUTHOR	Universal Ctags Team	//
 !_TAG_PROGRAM_NAME	Universal Ctags	/Derived from Exuberant Ctags/
 !_TAG_PROGRAM_URL	https://ctags.io/	/official site/
-!_TAG_PROGRAM_VERSION	5.9.0	//
+!_TAG_PROGRAM_VERSION	0.0.0	//
 CaseSensitiveSearchTest	CaseSensitiveSearchTest.java	/^public class CaseSensitiveSearchTest {$/;"	c
 CaseSensitiveSearchTestEnum	CaseSensitiveSearchTest.java	/^    public enum CaseSensitiveSearchTestEnum {$/;"	g	class:CaseSensitiveSearchTest
 DuplicateImports1	DuplicateImports1.java	/^    public DuplicateImports1(ImportedClass c, Interface i) {}$/;"	m	class:DuplicateImports1
@@ -19,6 +17,7 @@ ImportClassPackageNameMatchBug	ImportClassPackageNameMatchBug.java	/^public clas
 ImportStaticMethod	ImportStaticMethod.java	/^public class ImportStaticMethod {$/;"	c
 InnerClass	NestedClasses.java	/^        public InnerClass() {}$/;"	m	class:NestedClasses.InnerClass
 InnerClass	NestedClasses.java	/^    public class InnerClass {$/;"	c	class:NestedClasses
+InsertVariable	InsertVariable.java	/^public class InsertVariable {$/;"	c
 MY_NESTED_ENUM_VAL	NestedEnums.java	/^        MY_NESTED_ENUM_VAL$/;"	e	enum:NestedEnums.MyNestedEnum	file:
 MyNestedAnnotation	NestedAnnotations.java	/^    public @interface MyNestedAnnotation {}$/;"	a	class:NestedAnnotations
 MyNestedEnum	NestedEnums.java	/^    public enum MyNestedEnum {$/;"	g	class:NestedEnums
@@ -59,4 +58,5 @@ ca.example.vim	StaticImports.java	/^package ca.example.vim;$/;"	p
 ca.example.vim	Wildcard.java	/^package ca.example.vim;$/;"	p
 getSimpleInterface	SimpleInterface.java	/^	void getSimpleInterface(ImportedClass val1, Interface val2);$/;"	m	interface:SimpleInterface
 myStaticMethod	ImportStaticMethod.java	/^    public static myStaticMethod(ImportedClass c, Interface i) {}$/;"	m	class:ImportStaticMethod
+send	InsertVariable.java	/^    protected HttpResponse<String> send(final HttpRequest.Builder requestPrototype) throws IOExc/;"	m	class:InsertVariable
 uniquecasesensitivename	CaseSensitiveSearchTest.java	/^    public void uniquecasesensitivename() {$/;"	m	class:CaseSensitiveSearchTest

--- a/test/integration/templates.vimspec
+++ b/test/integration/templates.vimspec
@@ -1,0 +1,51 @@
+Describe Templates
+	After
+		%bwipeout!
+		let g:java_insert_var_declare_final = 1
+	End
+
+	Describe #InsertLocalVariable
+		It should insert a final var declaration on the cursor line
+			edit! test/input/InsertVariable.java
+
+			" position the cursor to the middle of line 4
+			call cursor(4, 27)
+
+			" sanity check
+			Assert Equals(getline(line('.')), '        prepareHeader(copy(), value)')
+
+			call java_support#templates#InsertLocalVariable()
+
+			" check the inserted text
+			Assert Equals(getline(line('.')), '        final var  = prepareHeader(copy(), value)')
+
+			" check the cursor position
+			let l:pos = getpos('.')
+			Assert Equals(l:pos[1], 4)
+			Assert Equals(l:pos[2], 19)
+		End
+
+		It should insert a non-final var declaration on the cursor line if configured accordingly
+			edit! test/input/InsertVariable.java
+
+			let g:java_insert_var_declare_final = 0
+
+			" position the cursor to the middle of line 4
+			call cursor(4, 27)
+
+			" sanity check
+			Assert Equals(getline(line('.')), '        prepareHeader(copy(), value)')
+
+			call java_support#templates#InsertLocalVariable()
+
+			" check the inserted text
+			Assert Equals(getline(line('.')), '        var  = prepareHeader(copy(), value)')
+
+			" check the cursor position
+			let l:pos = getpos('.')
+			Assert Equals(l:pos[1], 4)
+			Assert Equals(l:pos[2], 13)
+		End
+	End
+End
+


### PR DESCRIPTION
Introduce features for inserting a local variable declaration. These features aren't that smart, but handy. These features are only useful for Java 11+, leveraging type inference with 'var'.