### PR TITLE
introduce config for import popup

### DIFF
--- a/autoload/java_support/import.vim
+++ b/autoload/java_support/import.vim
@@ -97,6 +97,10 @@ function! s:ImportFromSelection(keyword, tag_results) abort
 		endif
 	endfunction
 
+	if !g:java_import_popup_show_always && len(a:tag_results) == 1
+		return s:PopupMenuCallback(0, 1)
+	endif
+
 	let l:popup_entries = s:BuildPopupEntries(a:tag_results, l:state)
 	call popup_create(l:popup_entries, {
 		\ 'line': 'cursor+1',

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -239,7 +239,16 @@ Default:
 --------------------------------------------------------------------------------
 IMPORT OPTIONS                                     *java-support-import-options*
 
-There are no import options at this time.
+                                             *'g:java_import_popup_show_always'*
+Configure when to show the popup when importing classes. By default, the popup
+is always shown when there are 1 or more results. If this option is set to zero,
+if there's only a single import result, that class will be automatically
+imported without showing a popup.
+
+Default:
+>
+	let g:java_import_popup_show_always = 1
+<
 
 --------------------------------------------------------------------------------
 INDEX OPTIONS                                       *java-support-index-options*

--- a/plugin/java_support.vim
+++ b/plugin/java_support.vim
@@ -25,6 +25,11 @@ if !exists('g:java_import_wildcard_count')
 	let g:java_import_wildcard_count = 0
 endif
 
+" By default, always show popup.
+if !exists('g:java_import_popup_show_always')
+	let g:java_import_popup_show_always = 1
+endif
+
 " By default, enable indexing progress.
 if !exists('g:java_import_index_progress')
 	let g:java_import_index_progress = 1


### PR DESCRIPTION
When there's only a single import result, being shown a popup is useful
for seeing the fully-qualified import beforehand, but it can be annoying
for some users. This revision introduces an option allowing the user to
configure when to display the popup.

By default, the popup is always shown. However, it's now possible to
configure the popup to only be shown when there's more than 1 result.
