### PR TITLE
filter imports in same package as current file

### DIFF
--- a/autoload/java_support/tags.vim
+++ b/autoload/java_support/tags.vim
@@ -16,7 +16,7 @@ function! java_support#tags#Lookup(keyword) abort
 			continue
 		endif
 
-		let l:package = s:FindPackageForFile(tag.filename)
+		let l:package = java_support#java#GetPackageForFile(tag.filename)
 		if empty(l:package)
 			continue
 		endif
@@ -60,42 +60,5 @@ function! java_support#tags#Lookup(keyword) abort
 	endfor
 
 	return l:prompt_results
-endfunction
-
-" Read the contents of `file` and look for a package statement.
-"
-" Loading the entire file into memory can be pretty wasteful, given that
-" package statements usually appear very close to the top of the file. To
-" reduce overhead, files are read incrementally. In the worst case, this could
-" result in multiple file reads, but in the normal case will improve overall
-" performance.
-"
-" If found, returns the package statement components. Otherwise returns an
-" empty list.
-function! s:FindPackageForFile(file) abort
-	let l:chunk = 10
-	let l:offset = 0
-
-	while v:true
-		let l:lines = readfile(a:file, '', l:chunk)
-
-		for line in l:lines[l:offset:-1]
-			let l:matches = matchlist(line, 'package\s\+\([^;]\+\);')
-
-			if !empty(l:matches)
-				return split(substitute(l:matches[1], '\s', '', 'g'), '\.')
-			endif
-		endfor
-
-		" if we have reached end of file
-		if len(l:lines) < l:chunk
-			return []
-		endif
-
-		let l:offset = len(l:lines)
-		let l:chunk *= 3
-	endwhile
-
-	return []
 endfunction
 

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -236,6 +236,14 @@ Default:
 	let g:java_import_wildcard_count = 0
 <
 
+                                           *'g:java_import_filter_same_package'*
+Filter imports that are in the same package as the current file.
+
+Default:
+>
+	let g:java_import_filter_same_package = 1
+<
+
 --------------------------------------------------------------------------------
 IMPORT OPTIONS                                     *java-support-import-options*
 

--- a/plugin/java_support.vim
+++ b/plugin/java_support.vim
@@ -25,6 +25,12 @@ if !exists('g:java_import_wildcard_count')
 	let g:java_import_wildcard_count = 0
 endif
 
+" By default, filter imports that are in the same package as the current java
+" file.
+if !exists('g:java_import_filter_same_package')
+	let g:java_import_filter_same_package = 1
+endif
+
 " By default, always show popup.
 if !exists('g:java_import_popup_show_always')
 	let g:java_import_popup_show_always = 1

--- a/test/input/ImportClassPackageNameMatchBug.java
+++ b/test/input/ImportClassPackageNameMatchBug.java
@@ -1,7 +1,7 @@
 package ca.example.vim;
 
-import ca.example.vim.Internal;
-import ca.example.vim.Internal.Interface;
+import ca.example.internal.vim.Internal;
+import ca.example.internal.vim.Internal.Interface;
 
 public class ImportClassPackageNameMatchBug {
     public ImportClassPackageNameMatchBug() {}

--- a/test/input/SortFilterSamePackage.java
+++ b/test/input/SortFilterSamePackage.java
@@ -1,0 +1,9 @@
+package ca.example.vim;
+
+import ca.example.vim.Filtered;
+import ca.example.vim.internal.NotFiltered;
+import ca.example.vim.external.NotFiltered;
+
+public class SortFilterSamePackage {
+
+}

--- a/test/input/Wildcard.java
+++ b/test/input/Wildcard.java
@@ -2,9 +2,9 @@ package ca.example.vim;
 
 import ca.example.vim.internal.Interface;
 import ca.example.vim.internal.Interface1;
-import ca.example.vim.ImportedClass;
-import ca.example.vim.ImportedClass1;
-import ca.example.vim.ImportedClass2;
+import ca.example.vim.internal2.ImportedClass;
+import ca.example.vim.internal2.ImportedClass1;
+import ca.example.vim.internal2.ImportedClass2;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;

--- a/test/integration/sort.vimspec
+++ b/test/integration/sort.vimspec
@@ -2,6 +2,7 @@ Describe sort
 	After
 		%bwipeout!
 		let g:java_import_wildcard_count = 0
+		let g:java_import_filter_same_package = 1
 	End
 
 	Describe #JavaSortImports
@@ -164,11 +165,11 @@ Describe sort
 			Assert Equals(len(l:import_lines), 1)
 
 			" ensure ca.example.vim imports were merged
-			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import ca\.example\.vim\.\*')
+			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import ca\.example\.vim\.internal2\.\*')
 			Assert Equals(len(l:import_lines), 1)
 
 			" ensure ca.example.vim.internal imports were not merged
-			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import ca\.example\.vim\.internal')
+			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import ca\.example\.vim\.internal\.')
 			Assert Equals(len(l:import_lines), 2)
 		End
 
@@ -178,8 +179,34 @@ Describe sort
 			call java_support#sort#JavaSortImports()
 
 			" ensure imports were not collapsed into one
-			Assert True(java_support#buffer#FindLineMatchingPattern('%', 1, 'import ca.example.vim.Internal;') > 0)
-			Assert True(java_support#buffer#FindLineMatchingPattern('%', 1, 'import ca.example.vim.Internal.Interface;') > 0)
+			Assert True(java_support#buffer#FindLineMatchingPattern('%', 1, 'import ca.example.internal.vim.Internal;') > 0)
+			Assert True(java_support#buffer#FindLineMatchingPattern('%', 1, 'import ca.example.internal.vim.Internal.Interface;') > 0)
+		End
+
+		It should filter imports that are in the same package as the current file
+			edit! test/input/SortFilterSamePackage.java
+
+			call java_support#sort#JavaSortImports()
+
+			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import')
+			Assert Equals(len(l:import_lines), 2)
+
+			Assert Equals(l:import_lines[0], 'import ca.example.vim.external.NotFiltered;')
+			Assert Equals(l:import_lines[1], 'import ca.example.vim.internal.NotFiltered;')
+		End
+
+		It should not filter imports that are in the same package as the current file if configured accordingly
+			edit! test/input/SortFilterSamePackage.java
+
+			let g:java_import_filter_same_package = 0
+			call java_support#sort#JavaSortImports()
+
+			let l:import_lines = java_support#buffer#FindLinesMatchingPattern('%', 1, '^import')
+			Assert Equals(len(l:import_lines), 3)
+
+			Assert Equals(l:import_lines[0], 'import ca.example.vim.Filtered;')
+			Assert Equals(l:import_lines[1], 'import ca.example.vim.external.NotFiltered;')
+			Assert Equals(l:import_lines[2], 'import ca.example.vim.internal.NotFiltered;')
 		End
 	End
 End


### PR DESCRIPTION
When sorting imports, filter any imports that are in the same package as
the current file. A configuration option has been introduced to disable
this feature.