### PR TITLE
skip tag results file missing files

### DIFF
--- a/autoload/java_support/tags.vim
+++ b/autoload/java_support/tags.vim
@@ -16,6 +16,10 @@ function! java_support#tags#Lookup(keyword) abort
 			continue
 		endif
 
+		if !filereadable(tag.filename)
+			continue
+		endif
+
 		let l:package = java_support#java#GetPackageForFile(tag.filename)
 		if empty(l:package)
 			continue


### PR DESCRIPTION
If a tag is found but the file is missing (common when working with a
version control system), skip the tag result instead of throwing an
error.