### PR TITLE
warn of unused imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,24 +19,29 @@ Plug 'brandon1024/java-support.vim'
 ```
 
 ## Usage
-To cleanup import statements:
+To optimize import statements:
 ```
-:Java cleanup-imports
+	:Java imports optimize
 ```
 
 To import a class or enum with a specific name:
 ```
-:Java import MyClass
+	:Java import MyClass
 ```
 
 To import a class or enum with a name under the cursor:
 ```
-:Java import
+	:Java import
 ```
 
 To re-index (cache) references from imports in the current project (cwd):
 ```
-:Java index
+	:Java index
+```
+
+To insert a local variable declaration under the current line:
+```
+	:Java insert-var
 ```
 
 This plugin uses tag files to locate classes and build fully-qualified class

--- a/autoload/java_support/import_tree.vim
+++ b/autoload/java_support/import_tree.vim
@@ -109,18 +109,39 @@ endfunction
 function! java_support#import_tree#MergeTrees(tree_a, tree_b) abort
 	let l:result = java_support#import_tree#BuildEmpty()
 
-	function! s:TreeNodeVisitor(name, meta, path, acc) abort closure
-		call java_support#import_tree#Merge(l:result, a:path, a:meta)
-	endfunction
-
 	call s:TraverseTree(a:tree_a,
-		\ { name, meta, path, acc -> s:TreeNodeVisitor(name, meta, path, acc) },
+		\ { name, meta, path, acc -> java_support#import_tree#Merge(l:result, path, meta) },
 		\ [], v:null)
 	call s:TraverseTree(a:tree_b,
-		\ { name, meta, path, acc -> s:TreeNodeVisitor(name, meta, path, acc) },
+		\ { name, meta, path, acc -> java_support#import_tree#Merge(l:result, path, meta) },
 		\ [], v:null)
 
 	return l:result
+endfunction
+
+" Remove a node from the tree. Returns whether or not the node existed in the
+" tree.
+function! java_support#import_tree#Remove(tree, path) abort
+	let l:leaf_name = remove(a:path, -1)
+
+	let l:node = a:tree
+	for node_name in a:path
+		let l:node = l:node['children']
+		if !has_key(l:node, node_name)
+			return v:false
+		endif
+
+		let l:node = l:node[node_name]
+	endfor
+
+	let l:node = l:node['leaf']
+	if !has_key(l:node, l:leaf_name)
+		return v:false
+	endif
+
+	call remove(l:node, l:leaf_name)
+
+	return v:true
 endfunction
 
 " Flatten `tree` into a flat list and return it.

--- a/autoload/java_support/plugin.vim
+++ b/autoload/java_support/plugin.vim
@@ -2,8 +2,19 @@
 function! java_support#plugin#Command(cmd, ...) abort
 	if a:cmd == 'import'
 		call java_support#import#JavaImportKeyword(a:0 == 1 ? a:1 : '')
-	elseif a:cmd == 'cleanup-imports'
-		call java_support#sort#JavaSortImports()
+	elseif a:cmd == 'imports'
+		if a:0 == 0
+			call java_support#sort#JavaSortImports()
+		endif
+
+		let l:subcommand = a:1
+		if l:subcommand == 'sort'
+			call java_support#sort#JavaSortImports()
+		elseif l:subcommand == 'optimize'
+			call java_support#import#FindUnused(a:0 == 2 ? a:1 : '%', v:true)
+		elseif l:subcommand == 'find-unused'
+			call java_support#import#FindUnused(a:0 == 2 ? a:1 : '%', v:false)
+		endif
 	elseif a:cmd == 'index'
 		if a:0 == 0
 			return java_support#index#IndexDirectory()
@@ -11,9 +22,9 @@ function! java_support#plugin#Command(cmd, ...) abort
 
 		let l:subcommand = a:1
 		if l:subcommand == 'buffer'
-			call java_support#index#IndexBuffer(a:0 == 1 ? a:1 : '')
+			call java_support#index#IndexBuffer(a:0 == 2 ? a:1 : '')
 		elseif l:subcommand == 'dir'
-			call java_support#index#IndexDirectory(a:0 == 1 ? a:1 : '')
+			call java_support#index#IndexDirectory(a:0 == 2 ? a:1 : '')
 		elseif l:subcommand == 'save'
 			call java_support#index#Save()
 		elseif l:subcommand == 'recover'

--- a/doc/java-support.txt
+++ b/doc/java-support.txt
@@ -56,7 +56,7 @@ Sort/Reformat Import Statements~
 	package, and configure the order of individual import groups.
 
 Optimize/Merge Import Statements~
-	Remove duplicate or unecessary import statements. Automatically merge
+	Remove duplicate or unused import statements. Automatically merge
 	same-package imports into a single wildcard import (when enabled).
 
 Class/Interface/Enum/Method Import~
@@ -70,9 +70,9 @@ Introduce Local Variable Declaration~
 ================================================================================
 USAGE                                                       |java-support-usage|
 
-To cleanup import statements:
+To optimize import statements:
 >
-	:Java cleanup-imports
+	:Java imports optimize
 <
 
 To import a class or enum with a specific name:
@@ -99,10 +99,23 @@ To insert a local variable declaration under the current line:
 COMMANDS                                                 *java-support-commands*
 
                                                                          *:Java*
-:Java cleanup-imports
+:Java imports [{subcommand} [{arg}]]
 	Clean up import statements in the current buffer. Import statements are
 	removed, optimized, sorted, and then written to the buffer just below the
 	package statement (if exists).
+
+	If {subcommand} is 'sort', import statements are sorted according to
+	|g:java_import_order| and other sort options. Duplicate imports are removed.
+
+	If {subcommand} is 'optimize', imports that are not referenced anywhere in
+	the buffer are removed. Import statements are sorted like the 'sort'
+	subcommand. A buffer name {arg} may be provided, defaulting to the current
+	buffer '%'.
+
+	If {subcommand} is 'find-unused', imports that are not referenced anywhere
+	in the buffer are added to the quickfix list for further inspection. Import
+	statements are sorted like the 'sort'. A buffer name {arg} may be provided,
+	defaulting to the current buffer '%'.
 
 :Java import [{name}]
 	Import a class and cleanup the imports.

--- a/test/input/FindUnusedImports.java
+++ b/test/input/FindUnusedImports.java
@@ -1,0 +1,16 @@
+package ca.example.vim;
+
+import ca.example.vim.internal.Used;
+import ca.example.vim.internal.Unused;
+
+public class FindUnusedImports {
+
+    public void example() {
+        Used.doThing();
+
+        // make sure these don't match
+        UnusedNO
+        NOUnused
+        unused
+    }
+}

--- a/test/integration/import.vimspec
+++ b/test/integration/import.vimspec
@@ -25,6 +25,39 @@ Describe Import
 		End
 	End
 
+	Describe #FindUnused
+		Before
+			call setqflist([], 'r')
+		End
+
+		It should find unused imports and add them to the quickfix list
+			edit! test/input/FindUnusedImports.java
+
+			call java_support#import#FindUnused()
+
+			let l:errors = getqflist()
+			Assert Equals(len(l:errors), 1)
+
+			let l:error = l:errors[0]
+			Assert Equals(l:error['pattern'], 'ca.example.vim.internal.Unused')
+			Assert Equals(l:error['text'], 'ca.example.vim.internal.Unused')
+
+			let l:tree = java_support#import_tree#BuildFromBuffer()
+			Assert True(test_utils#tree#HasNode(l:tree, 'ca.example.vim.internal.Unused'))
+		End
+
+		It should remove unused imports
+			edit! test/input/FindUnusedImports.java
+
+			call java_support#import#FindUnused('%', v:true)
+			
+			Assert True(empty(getqflist()))
+
+			let l:tree = java_support#import_tree#BuildFromBuffer()
+			Assert False(test_utils#tree#HasNode(l:tree, 'ca.example.vim.internal.Unused'))
+		End
+	End
+
 	Describe #ResultComparator
 		It should sort results by kind
 			let l:results = [

--- a/test/unit/import_tree.vimspec
+++ b/test/unit/import_tree.vimspec
@@ -395,6 +395,40 @@ Describe import_tree
 		End
 	End
 
+	Describe #Remove
+		It should not remove nodes that do not exist in tree
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;'
+				\ ]
+
+			let l:tree = java_support#import_tree#BuildFromStatements(l:statements)
+
+			let l:removed = java_support#import_tree#Remove(l:tree, ['java', 'util', 'Collection'])
+			Assert False(l:removed)
+
+			let l:removed = java_support#import_tree#Remove(l:tree, ['java', 'util', 'List', 'Deeper'])
+			Assert False(l:removed)
+		End
+
+		It should correctly remove node from the tree
+			let l:statements = [
+					\ 'import javax.servlet.FilterChain;',
+					\ 'import java.util.Collections;',
+					\ 'import java.util.List;',
+					\ 'import java.util.List.Deeper;'
+				\ ]
+
+			let l:tree = java_support#import_tree#BuildFromStatements(l:statements)
+
+			let l:removed = java_support#import_tree#Remove(l:tree, ['java', 'util', 'List'])
+			Assert True(l:removed)
+			Assert False(test_utils#tree#HasNode(l:tree, 'java.util.List'))
+			Assert True(test_utils#tree#HasNode(l:tree, 'java.util.List.Deeper'))
+		End
+	End
+
 	Describe #Index
 		It should flatten tree into a dictionary keyed by leaf name
 			let l:statements = [


### PR DESCRIPTION
Introduce a feature for finding unused imports in a buffer. This works by perming a basic pattern match for the imported class name in the buffer.